### PR TITLE
Improvements in parameters and Controller initialization

### DIFF
--- a/nanoFramework.TI.EasyLink/EasyLinkController.cs
+++ b/nanoFramework.TI.EasyLink/EasyLinkController.cs
@@ -115,11 +115,10 @@ namespace nanoFramework.TI.EasyLink
         /// <summary>
         /// Initializes the radio with specified Phy settings.
         /// </summary>
-        /// <returns>
-        /// </returns>
+        /// <param name="phyTYpe"><see cref="PhyType"/> settings to initialize the radio with.</param>
         /// <remarks>
         /// </remarks>
-        public EasyLinkController(PhyType phyTYpe = PhyType._50kbps2gfsk)
+        public EasyLinkController(PhyType phyTYpe)
         {
             _phyType = phyTYpe;
 
@@ -168,7 +167,7 @@ namespace nanoFramework.TI.EasyLink
             {
                 if (_initialized)
                 {
-                    return (Status)TransmitNative(packet, Timeout.Infinite, 0);
+                    return (Status)TransmitNative(packet, Timeout.InfiniteTimeSpan, TimeSpan.Zero);
                 }
                 else
                 {
@@ -181,12 +180,24 @@ namespace nanoFramework.TI.EasyLink
         /// Sends a Packet. This method blocks execution of the current thread until the packet transmission in complete.
         /// </summary>
         /// <param name="packet">The <see cref="TransmitPacket"/> to be transmitted.</param>
+        /// <param name="timeout">The timeout value for the transmission operation to complete successfully.</param>
+        /// <param name="dueTime"> The amount of time to delay before starting the transmission.</param>
+        /// <returns>The operation result.</returns>
+        public Status Transmit(TransmitPacket packet, TimeSpan timeout)
+        {
+            return Transmit(packet, timeout, TimeSpan.Zero);
+        }
+
+        /// <summary>
+        /// Sends a Packet. This method blocks execution of the current thread until the packet transmission in complete.
+        /// </summary>
+        /// <param name="packet">The <see cref="TransmitPacket"/> to be transmitted.</param>
         /// <param name="timeout">The timeout value (in milliseconds) for the transmission operation to complete successfully.</param>
         /// <param name="dueTime"> The amount of time to delay before starting the transmission, in milliseconds. 
         /// Specify zero (0) to start the timer immediately.
         /// </param>
         /// <returns>The operation result.</returns>
-        public Status Transmit(TransmitPacket packet, int timeout, int dueTime = 0)
+        public Status Transmit(TransmitPacket packet, TimeSpan timeout, TimeSpan dueTime)
         {
             lock (_syncLock)
             {
@@ -213,7 +224,7 @@ namespace nanoFramework.TI.EasyLink
             {
                 if (_initialized)
                 {
-                    return (Status)ReceiveNative(out packet, Timeout.Infinite);
+                    return (Status)ReceiveNative(out packet, Timeout.InfiniteTimeSpan);
                 }
                 else
                 {
@@ -232,7 +243,7 @@ namespace nanoFramework.TI.EasyLink
         /// <param name="packet">The received packet.</param>
         /// <param name="timeout">The timeout value for the reception operation to complete successfully.</param>
         /// <returns>The operation result.</returns>
-        public Status Receive(out ReceivedPacket packet, int timeout)
+        public Status Receive(out ReceivedPacket packet, TimeSpan timeout)
         {
             lock (_syncLock)
             {
@@ -410,7 +421,7 @@ namespace nanoFramework.TI.EasyLink
         private extern byte InitNative();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern byte ReceiveNative(out ReceivedPacket packet, int timeout);
+        private extern byte ReceiveNative(out ReceivedPacket packet, TimeSpan timeout);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern byte SetConfigurationNative(ControlOption option, uint value);
@@ -422,7 +433,7 @@ namespace nanoFramework.TI.EasyLink
         private extern byte SetRfPowerNative(sbyte rfPower);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern byte TransmitNative(TransmitPacket packet, int timeout, int dueTime);
+        private extern byte TransmitNative(TransmitPacket packet, TimeSpan timeout, TimeSpan dueTime);
 
         #endregion
     }

--- a/nanoFramework.TI.EasyLink/Properties/AssemblyInfo.cs
+++ b/nanoFramework.TI.EasyLink/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.0.0.2")]
+[assembly: AssemblyNativeVersion("100.0.0.3")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/nanoFramework.TI.EasyLink/nanoFramework.TI.EasyLink.nfproj
+++ b/nanoFramework.TI.EasyLink/nanoFramework.TI.EasyLink.nfproj
@@ -33,6 +33,15 @@
     <Name>nanoFramework.TI.EasyLink</Name>
   </PropertyGroup>
   <ItemGroup>
+    <NFMDP_PE_ExcludeClassByName Include="ControlOption">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="PhyType">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="Status">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
     <NFMDP_PE_ExcludeClassByName Include="ThisAssembly">
       <InProject>false</InProject>
     </NFMDP_PE_ExcludeClassByName>


### PR DESCRIPTION
## Description
- Controller constructor now requires a PHY configuration. No more default parameter.
- Transmit and Receive methods new use TimeSpan as parameters.
- Bump AssemblyNativeVersion to v100.0.0.3.

## Motivation and Context
- Having a constructor with a default parameter for the PHY settings can be elusive. It's better to have the developer clearly stating what is the PHY settings intended to be used.
- Using `TimeSpan` arguments makes it clear and less error prone than using a milliseconds value.

## How Has This Been Tested?<!-- (if applicable) -->
- TI EasyLink sample.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
